### PR TITLE
Corrigindo painel de estatísticas github

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="">
   <a href="https://github.com/leovnoliveira">
-    <img height="145em" src="https://github-readme-stats.vercel.app/api?username=leovnoliveira&count_private=true&include_all_commits=true&show_icons=true&theme=dracula&hide_border=false&show_owner=true&v=2"/>
+    <img height="145em" src="https://github-readme-stats.vercel.app/api?username=leovnoliveira&count_private=true&show_icons=true&theme=dracula&hide_border=false&include_all_commits=true&v=2"/>
     <img height="145em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=leovnoliveira&theme=dracula&hide_border=false&&layout=compact&v=2"/>
   </a>
 </div>


### PR DESCRIPTION
Correções na chave token. 

Entrei durante a tarde no meu perfil e não estava aparecendo as estatísticas. Regerenei a chave token e atualizei dentro do Actions no meu repositório git-stats-read-me forkeado, cujo PAT_1 foi atualizado.